### PR TITLE
use current directory for output folder

### DIFF
--- a/sp_experiment/sp.py
+++ b/sp_experiment/sp.py
@@ -77,7 +77,7 @@ fname = 'sub-{}_task-sp{}_events.tsv'.format(args.sub_id, args.condition)
 
 # Check directory is present and file name not yet used
 init_dir = op.dirname(sp_experiment.__file__)
-data_dir = op.join(init_dir, 'experiment_data')
+data_dir = op.join(os.getcwd(), 'experiment_data')
 if not op.exists(data_dir):
     os.mkdir(data_dir)
 


### PR DESCRIPTION
`sp_experiment.__file__` is always hidden in `site-packages` otherwise

Just a thought.