### PR TITLE
Pr03 pyinstaller

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,3 +18,6 @@ passive-test-run:
 
 test:
 	pytest --verbose --cov=sp_experiment
+
+package:
+	pyinstaller build.spec

--- a/build.spec
+++ b/build.spec
@@ -1,0 +1,32 @@
+# -*- mode: python -*-
+
+block_cipher = None
+
+
+a = Analysis(['sp_experiment/sp.py'],
+             pathex=['./sp_experiment'],
+             binaries=[],
+             datas=[ ('sp_experiment/*json', 'sp_experiment') ],
+             hiddenimports=[],
+             hookspath=[],
+             runtime_hooks=[],
+             excludes=['arabic_reshaper'],
+             win_no_prefer_redirects=False,
+             win_private_assemblies=False,
+             cipher=block_cipher,
+             noarchive=False)
+pyz = PYZ(a.pure, a.zipped_data,
+             cipher=block_cipher)
+exe = EXE(pyz,
+          a.scripts,
+          a.binaries,
+          a.zipfiles,
+          a.datas,
+          [],
+          name='sp_experiment',
+          debug=False,
+          bootloader_ignore_signals=False,
+          strip=False,
+          upx=True,
+          runtime_tmpdir=None,
+          console=True )

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ if version is None:
     raise RuntimeError('Could not determine version')
 
 dependencies = [
-    'numpy',
+    'numpy~=1.16.1',
     'scipy',
     'matplotlib',
     'pandas',
@@ -27,6 +27,7 @@ dependencies = [
     'psychopy==3.0.0',
     'pytest',
     'pytest-cov',
+    'pyinstaller',
 ]
 
 
@@ -39,6 +40,7 @@ setup(name='sp_experiment',
       license='BSD 3-Clause License',
       classifiers=[
           'Programming Language :: Python :: 3.6',
+          'Programming Language :: Python :: 3.7',
           'Operating System :: Microsoft :: Windows',
       ],
       packages=find_packages(),

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ if version is None:
     raise RuntimeError('Could not determine version')
 
 dependencies = [
+    'sip',
     'numpy~=1.16.1',
     'scipy',
     'matplotlib',

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,24 @@ with open(os.path.join('sp_experiment', '__init__.py'), 'r') as fid:
 if version is None:
     raise RuntimeError('Could not determine version')
 
+dependencies = [
+    'numpy',
+    'scipy',
+    'matplotlib',
+    'pandas',
+    'pyopengl',
+    'pyglet~=1.3.0',
+    'pillow',
+    'moviepy',
+    'lxml',
+    'openpyxl',
+    'configobj',
+    'psychopy==3.0.0',
+    'pytest',
+    'pytest-cov',
+]
+
+
 setup(name='sp_experiment',
       version=version,
       description='Implemetation of the Sampling Paradigm in PsychoPy',
@@ -19,5 +37,11 @@ setup(name='sp_experiment',
       author='Stefan Appelhoff',
       author_email='stefan.appelhoff@mailbox.org',
       license='BSD 3-Clause License',
+      classifiers=[
+          'Programming Language :: Python :: 3.6',
+          'Operating System :: Microsoft :: Windows',
+      ],
       packages=find_packages(),
+      install_requires=dependencies,
+      package_data={'': ['*.json']},
       zip_safe=False)


### PR DESCRIPTION
I was able to build a single `ELF` / `.exe` on Ubuntu Xenial and Windows 10 respectively with `make package`. I couldn't really run the experiment because of hardware requirements, but the initial loading seems to work fine.

So with this approach you could just deploy a single exe to a target and using #2 the output would be written to the exe's current working directory.

There was some issue with an `arabic_reshaper` module (don't know what included that) and excluding that from the build worked around the issue. Also, the json files need to be added to the archive explicitly again. Pyinstaller is using its own analysis of  `sp_experiment/sp.py`.